### PR TITLE
formatting change

### DIFF
--- a/Authentication/OAuth 2.0.md
+++ b/Authentication/OAuth 2.0.md
@@ -65,6 +65,8 @@ GET https://api.harvestapp.com/account/who_am_i ?
     access_token=Jjv5cUAnQx7R9jEECHNRxan7iMprt0ySncJhDdzQbtc%2FQXhMZcNVPQtJuBiDajPqNUz79o7S0FNvWc2WwIDcMA%3D%3D
 ```
 
+**remember to set the `Content-Type` and `Accept` headers for this request**
+
 6. *Request a new access token* after 18 hours using the refresh token within 30 days.
 
 ```


### PR DESCRIPTION
I was finding the formatting of the urls on the OAuth 2.0 Authentication page a bit frustrating to read on github because there weren't any line breaks, so I've put them into blocks so you can see the parameters easier.

Also altered the json sections to be valid so they aren't highlighted in red.
