### PR TITLE
Be more explicit about the meaning of `retainer_id` in invoice output

### DIFF
--- a/Sections/Invoices.md
+++ b/Sections/Invoices.md
@@ -47,7 +47,7 @@ HTTP Response: 200 Success
     <recurring-invoice-id type="integer" nil="true"></recurring-invoice-id>
       <!-- was this converted from an estimate? -->
     <estimate-id type="integer" nil="true"></estimate-id>
-      <!-- retainer invoice? -->
+      <!-- does invoice fund a retainer? -->
     <retainer-id type="integer">12345</retainer-id>
     <updated-at type="datetime">2008-04-09T12:07:56Z</updated-at>
     <created-at type="datetime">2008-04-09T12:07:56Z</created-at>


### PR DESCRIPTION
 @lanej0 @bjhess @scottsemple 

The presence of a `retainer_id` indicates that the invoice funded a retainer. It has no relation to whether the invoice is drawing from a retainer. This hopefully makes that more explicit.

Currently there is no indication that an invoice is _drawing from_ an existing retainer. 
