### PR TITLE
Prefer use of example.com as suggested by RFC 2606

### DIFF
--- a/Authentication/HTTP Basic.md
+++ b/Authentication/HTTP Basic.md
@@ -7,7 +7,7 @@ HTTP Basic authentication is the oldest and simplest way to start working with t
 To interact with Harvest in this example we're going to use XML. To make requests in XML, specify application/xml for your Content-Type and Accept headers. A simple example with [curl](http://en.wikipedia.org/wiki/CURL):
 
 ```sh
-curl -H 'Content-Type: application/xml' -H 'Accept: application/xml' -u "user@email.com:password" https://subdomain.harvestapp.com/account/who_am_i
+curl -H 'Content-Type: application/xml' -H 'Accept: application/xml' -u "user@example.com:password" https://subdomain.harvestapp.com/account/who_am_i
 ```
 
 Successful requests return HTTP response codes in the 2xx range (e.g. 200, 201, etc.). Other response codes indicate a failed request or missing resource, in which case an error message may be provided. When successful, the above request returns:
@@ -41,5 +41,5 @@ Authorization: Basic (insert your authentication string here)
 Your authentication string is a base64 encoded version of your credentials. You can generate this in Ruby:
 
 ```http
-Base64.encode64("my@email.com:password").delete("\r\n")
+Base64.encode64("myemail@example.com:password").delete("\r\n")
 ```

--- a/Authentication/OAuth 2.0.md
+++ b/Authentication/OAuth 2.0.md
@@ -20,7 +20,7 @@ Harvest uses the [Authorization Code flow](http://tools.ietf.org/html/draft-ietf
     ```
     GET https://api.harvestapp.com/oauth2/authorize ?
         client_id=NMBEWl3h0r4KKNhfOsmPJw%3D%3D &
-        redirect_uri=https%3A%2F%2Fyourapp.com%2Fredirect_path &
+        redirect_uri=https%3A%2F%2Fexample.com%2Fredirect_path &
         state=optional-csrf-token &
         response_type=code
     ```
@@ -30,7 +30,7 @@ Harvest uses the [Authorization Code flow](http://tools.ietf.org/html/draft-ietf
 2. *Get the authorization code* when Harvest redirects back to your application. Harvest sends it to your redirect URI as a query parameter.
 
     ```
-    GET https://yourapp.com/redirect_path ?
+    GET https://example.com/redirect_path ?
         code=Ao%2ByCqyGInOKuHVIMkwZGlk%2Nvq9Kt3eDGBpKvZnvWP4latLD6umv2dD76C100YbSABOEwUFqieosQRjNH7qvsA%3D%3D &
         state=optional-csrf-token
     ```
@@ -110,7 +110,7 @@ Harvest uses the [Implicit Grant flow](http://tools.ietf.org/html/draft-ietf-oau
     ```
     GET https://api.harvestapp.com/oauth2/authorize ?
         client_id=NMBEWl3h0r4KKNhfOsmPJw%3D%3D &
-        redirect_uri=https%3A%2F%2Fyourapp.com%2Fredirect_path &
+        redirect_uri=https%3A%2F%2Fexample.com%2Fredirect_path &
         state=optional-csrf-token &
         response_type=token
     ```
@@ -120,7 +120,7 @@ Harvest uses the [Implicit Grant flow](http://tools.ietf.org/html/draft-ietf-oau
 2. *Get the access token* when Harvest redirects back to your application. Harvest sends it to your redirect URI as a hash parameter.
 
     ```
-    GET https://yourapp.com/redirect_path #
+    GET https://example.com/redirect_path #
         access_token=Ao%2ByCqyGInOKuHVIMkwZGlk%2Fvq9Kt3eDGBpKvZnvWP4latLD6umv2dT76C100YbSABOEwUFqieosQRjNH7qvsA%3D%3D &
         expires_in=64799 &
         state=optional-csrf-token &

--- a/Sections/Accounts.md
+++ b/Sections/Accounts.md
@@ -37,7 +37,7 @@ HTTP Response: 200 Success
     <timezone>Pacific Time (US &amp; Canada)</timezone>
     <timezone-utc-offset type="integer">-25200</timezone-utc-offset>
     <id type="integer">123456</id>
-    <email>jane@doe.com</email>
+    <email>janedoe@example.com</email>
     <admin type="boolean">true</admin>
     <first-name>Jane</first-name>
     <last-name>Doe</last-name>

--- a/Sections/Client Contacts.md
+++ b/Sections/Client Contacts.md
@@ -17,7 +17,7 @@ HTTP Response: 200 Success
     <client-id type="integer">11072</client-id>
     <fax>555.555.9999</fax>
     <last-name>Doe</last-name>
-    <email>Jane@Doe.com</email>
+    <email>janedoe@example.com</email>
     <first-name>Jane</first-name>
     <phone-mobile>555.555.7777</phone-mobile>
   </contact>
@@ -47,7 +47,7 @@ HTTP Response: 200 Success
     <client-id type="integer">11072</client-id>
     <fax>555.555.9999</fax>
     <last-name>Doe</last-name>
-    <email>Jane@Doe.com</email>
+    <email>janedoe@example.com</email>
     <first-name>Jane</first-name>
     <phone-mobile>555.555.7777</phone-mobile>
   </contact>
@@ -76,7 +76,7 @@ HTTP Response: 200 Success
   <client-id type="integer">11072</client-id>
   <fax>555.555.9999</fax>
   <last-name>Doe</last-name>
-  <email>Jane@Doe.com</email>
+  <email>janedoe@example.com</email>
   <first-name>Jane</first-name>
   <phone-mobile>555.555.7777</phone-mobile>
 </contact>
@@ -95,7 +95,7 @@ You need to post the following:
 ```xml
 <contact>
   <client-id type="integer">9</client-id>
-  <email>Jane@Doe.com</email>
+  <email>janedoe@example.com</email>
   <first-name>Jane</first-name>
   <last-name>Doe</last-name>
   <phone-office>555.555.5555</phone-office>
@@ -120,7 +120,7 @@ You can update selected attributes for a client contact.
 ```xml
 <contact>
   <client-id type="integer">9</client-id>
-  <email>Jane@JaneDoe.com</email>
+  <email>jdoe@example.com</email>
   <first-name>Jane</first-name>
   <last-name>Doe</last-name>
   <phone-office>555.555.1111</phone-office>

--- a/Sections/Clients.md
+++ b/Sections/Clients.md
@@ -24,7 +24,7 @@ HTTP Response: 200 Success
     USA
     212-555-1212
     212-555-1213 (fax)
-    http://www.company.com</details>
+    http://www.example.com</details>
     <default-invoice-timeframe>20110101,20111231</default-invoice-timeframe>
     <last-invoice-kind>task</last-invoice-kind>
   </client>
@@ -63,7 +63,7 @@ HTTP Response: 200 Success
   USA
   212-555-1212
   212-555-1213 (fax)
-  http://www.company.com</details>
+  http://www.example.com</details>
   <default-invoice-timeframe>20110101,20111231</default-invoice-timeframe>
   <last-invoice-kind>task</last-invoice-kind>
 </client>
@@ -92,7 +92,7 @@ You need to post the following:
   USA
   212-555-1212
   212-555-1213 (fax)
-  http://www.company.com</details>
+  http://www.example.com</details>
 </client>
 ```
 
@@ -117,7 +117,7 @@ You may update selected attributes for a client.
   USA
   212-555-1212
   212-555-1213 (fax)
-  http://www.company.com</details>
+  http://www.example.com</details>
 </client>
 ```
 

--- a/Sections/Invoice Messages.md
+++ b/Sections/Invoice Messages.md
@@ -19,9 +19,9 @@ HTTP Response: 200 Success
     <invoice-id type="integer">1420</invoice-id>
     <send-me-a-copy type="boolean">true</send-me-a-copy>
     <sent-by>My Name</sent-by>
-    <sent-by-email>my@email.com</sent-by-email>
-      <!-- comma separated list of recipient email addresses using the "Name <emai@domain.com>" format -->
-    <full-recipient-list>Jane Doe &lt;jane@doe.org&gt;,My Name &lt;my@email.com&gt;</full-recipient-list>
+    <sent-by-email>myemail@example.com</sent-by-email>
+      <!-- comma separated list of recipient email addresses using the "Name <username@example.com>" format -->
+    <full-recipient-list>Jane Doe &lt;janedoe@example.org&gt;,My Name &lt;myemail@example.com&gt;</full-recipient-list>
     <updated-at type="datetime">2008-04-09T12:07:56Z</updated-at>
     <created-at type="datetime">2008-04-09T12:07:56Z</created-at>
   </invoice-message>
@@ -43,8 +43,8 @@ HTTP Response: 200 Success
   <invoice-id type="integer">1420</invoice-id>
   <send-me-a-copy type="boolean">true</send-me-a-copy>
   <sent-by>My Name</sent-by>
-  <sent-by-email>my@email.com</sent-by-email>
-  <full-recipient-list>Jane Doe &lt;jane@doe.org&gt;,My Name &lt;my@email.com&gt;</full-recipient-list>
+  <sent-by-email>myemail@example.com</sent-by-email>
+  <full-recipient-list>Jane Doe &lt;janedoe@example.org&gt;,My Name &lt;myemail@example.com&gt;</full-recipient-list>
   <updated-at type="datetime">2008-04-09T12:07:56Z</updated-at>
   <created-at type="datetime">2008-04-09T12:07:56Z</created-at>
 </invoice-message>

--- a/Sections/Invoice Payments.md
+++ b/Sections/Invoice Payments.md
@@ -17,7 +17,7 @@ HTTP Response: 200 Success
     <notes>check</notes>
     <paid-at type="datetime">2008-02-14T00:00:00Z</paid-at>
     <recorded-by>Happy Owner</recorded-by>
-    <recorded-by-email>happy@owner.com</recorded-by-email>
+    <recorded-by-email>happyowner@example.com</recorded-by-email>
     <updated-at type="datetime">2008-04-09T12:07:56Z</updated-at>
     <created-at type="datetime">2008-04-09T12:07:56Z</created-at>
   </payment>
@@ -38,7 +38,7 @@ HTTP Response: 200 Success
   <notes>Finally.</notes>
   <paid-at type="datetime">2008-02-14T00:00:00Z</paid-at>
   <recorded-by>Happy Owner</recorded-by>
-  <recorded-by-email>happy@owner.com</recorded-by-email>
+  <recorded-by-email>happyowner@example.com</recorded-by-email>
   <updated-at type="datetime">2008-04-09T12:07:56Z</updated-at>
   <created-at type="datetime">2008-04-09T12:07:56Z</created-at>
 </payment>

--- a/Sections/People.md
+++ b/Sections/People.md
@@ -9,7 +9,7 @@ HTTP Response: 200 Success
 ```xml
 <user>
   <id type="integer">54234</id>
-  <email>Jane@Doe.com</email>
+  <email>janedoe@example.com</email>
   <first-name>Jane</first-name>
   <last-name>Doe</last-name>
     <!-- If true the user will be added to all new projects automatically -->
@@ -42,7 +42,7 @@ HTTP Response: 200 Success
 <users>
   <user>
     <id type="integer">54234</id>
-    <email>Jane@Doe.com</email>
+    <email>janedoe@example.com</email>
     <first-name>Jane</first-name>
     <last-name>Doe</last-name>
       <!-- If true the user will be added to all new projects automatically -->
@@ -84,7 +84,7 @@ Sample post:
 <user>
   <first-name>Edgar</first-name>
   <last-name>Ruth</last-name>
-  <email>edgar@ruth.com</email>
+  <email>edgarruth@example.com</email>
   <timezone>Central Time (US &amp; Canada)</timezone>
   <is-admin type="boolean">false</is-admin>
   <telephone>444-444</telephone>
@@ -115,7 +115,7 @@ You can update selected attributes for a user. Note that updates to password are
 <user>
   <first_name>John</first-name>
   <last_name>Doe</last-name>
-  <email>john@doe.com</email>
+  <email>johndoe@example.com</email>
   <timezone>Central Time (US & Canada)</timezone>
   <is_admin type="boolean">true</is-admin>
   <telephone>212-555-1212</telephone>


### PR DESCRIPTION
Updates domains and email addresses used in examples to example.com as some of the URLs pointed to live domains up for sale. 
