### PR TITLE
Update Invoice timeframe filter to correct YYYY-MM-DD format

### DIFF
--- a/Sections/Invoices.md
+++ b/Sections/Invoices.md
@@ -68,7 +68,7 @@ HTTP Response: 200 Success
 
 You can also query invoices by timeframe based on issue date.
 
-GET `/invoices?from=YYYYMMDD&to=YYYYMMDD`
+GET `/invoices?from=YYYY-MM-DD&to=YYYY-MM-DD`
 
 HTTP Response: 200 Success
 


### PR DESCRIPTION
Sending

```
/invoices?from=YYYYMMDD&to=YYYYMMDD
```

will ignore filter, but changing to

```
/invoices?from=YYYY-MM-DD&to=YYYY-MM-DD
```

will return results desired.

Fixes #50
